### PR TITLE
fix hasScope User

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -51,15 +51,15 @@ class User extends Model
 
         foreach ($scopes as $scope) {
             if (str_contains($scope, '/')) {
-                if (in_array($scope, $user, true) || in_array(preg_replace('#/.*#', '', $scope), $user, true)) {
-                    return true;
+                if (!in_array($scope, $user, true) && !in_array(preg_replace('#/.*#', '', $scope), $user, true)) {
+                    return false;
                 }
-            } elseif (in_array($scope, $user, true)) {
-                return true;
+            } elseif (!in_array($scope, $user, true)) {
+                return false;
             }
         }
 
-        return false;
+        return true;
     }
 
     public function role(): BelongsTo


### PR DESCRIPTION
Если для получения ролей пользователя, например, $scope = ['users', 'users-roles'], то если пользователь имеет хотя бы 1 из этих разрешений, он успешно проходил проверку.  Сейчас же наоборот.